### PR TITLE
Added a simple image Module and usage example with ppmio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,9 @@ set(CMAKE_MODULE_PATH
 include(MacroOutOfSourceBuild)
 macro_ensure_out_of_source_build(
   "Please build ${PROJECT_NAME} out-of-source")
+  
+# Conditionally turn on/off parts of the build (global-level)
+option(BUILD_MODULE_SIMPLEIMAGE "Build the simpleimage module and example" ON)
 
 ################################################
 ## Bring in dependent projects
@@ -24,6 +27,12 @@ elseif(FORCE_OPENCV2)
 else()
   find_package(OpenCV REQUIRED)
 endif()
+
+#Build submodules
+if(BUILD_MODULE_SIMPLEIMAGE)
+  add_definitions(-DBUILD_MODULE_SIMPLEIMAGE=ON)
+  add_subdirectory(simpleimage)
+endif() 
 
 ################################################
 ## Build the examples

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ What is included?
   messages from the camera.
 * [ex-pcicclient_set_io](ex-pcicclient_set_io.cpp) Shows how to mutate the digial IO pins
   on the O3D camera by the PCIC interface.
+* [ex-simpleImage_ppm_io](simpleimage/example/ex-simpleImage_ppm_io.cpp) Shows how to write your own
+  image container which does not depend on PCL nor OpenCV.
 
 LICENSE
 -------

--- a/simpleimage/CMakeLists.txt
+++ b/simpleimage/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.5)
+cmake_policy(SET CMP0048 NEW)
+
+# Global compiler flags
+set(CMAKE_BUILD_TYPE Release) # Release or Debug
+set(CMAKE_CXX_EXTENSIONS OFF) # OFF -> -std=c++14, ON -> -std=gnu++14
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED true)
+
+################################################
+## finding the ifm3d lib. Not needed in this repo
+## but will be useful for making this independent of 
+## ifm3d-example
+################################################
+find_package(ifm3d 0.9.0 CONFIG
+  REQUIRED COMPONENTS camera framegrabber 
+  )
+
+# simpleimage module 
+add_subdirectory(simpleimage)
+# ppm-io-master for writing ppm file
+add_subdirectory(ppm-io-master)
+#example which used simpleimage and ppm-io-module
+add_subdirectory(example)
+
+
+

--- a/simpleimage/README.md
+++ b/simpleimage/README.md
@@ -1,0 +1,47 @@
+
+ifm3d - Simple Image Container 
+===============================
+
+`ifm3d`, through its modularity, also encourages the
+creation of new image containers to be utilized within the overall `ifm3d`
+ecosystem. The interface is explained is very well in
+[ifm3d image conatiners](https://github.com/lovepark/ifm3d/blob/master/doc/img_container.md)
+
+`simpleimage` container is an header only interface for ifm3d lib which is independent of any third party library. 
+Following are the structure used in this module for storing image, point and pointClouds
+**Image** 
+```c++
+struct Img
+  {
+    std::vector<std::uint8_t> data;
+    int width;
+    int height;
+    pixel_format format;
+  };
+```
+**point**
+```c++
+  struct Point
+  {
+    float x;
+    float y;
+    float z;
+  };
+ ```
+**pointCloud**
+```c++
+ struct PointCloud
+ {
+   std::vector<Point> points;
+   int width;
+   int height;
+ };
+```
+[pixel_format](https://github.com/lovepark/ifm3d/blob/master/modules/framegrabber/include/ifm3d/fg/byte_buffer.h)
+
+The example in this modules explains how to grab the data from the ifm 3d devices and saved a .ppm image using [ppm-io](https://github.com/thinks/ppm-io) module.  To save the images the data is scaled to uint8 format. Amplitude image data is scaled by the minimum and maximum value in the grabbed amplitude data, whereas for Distance image the data is scaled in distance range from 0.0m to 2.5m, which means the data values after 2.5m will be shown as 255. 
+
+simpleimage module is configured in such a way that it can be build outside ifm3d-example repository which can be helpful for build applications  which do not want to add OPenCV or PCL as a dependency.
+
+If you have questions, feel free to ask on our
+[issue tracker](https://github.com/lovepark/ifm3d/issues).

--- a/simpleimage/example/CMakeLists.txt
+++ b/simpleimage/example/CMakeLists.txt
@@ -1,0 +1,14 @@
+
+################################################
+## Build the examples
+################################################
+
+add_executable(ex-simpleImage_ppm_io ex-simpleImage_ppm_io.cpp)
+
+target_link_libraries(ex-simpleImage_ppm_io
+                      ifm3d::camera
+                      ifm3d::framegrabber
+					  simpleimage
+					  ppmio
+                      )
+

--- a/simpleimage/example/ex-simpleImage_ppm_io.cpp
+++ b/simpleimage/example/ex-simpleImage_ppm_io.cpp
@@ -1,0 +1,171 @@
+/*
+ * Copyright (C) 2018 ifm electronic, gmbh
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distribted on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ //
+ // ex-simpleimage_ppm_io.cpp
+ //
+ // This example shows how to get the images from ifm3dlib without opencv and PCL dependency
+ // and how to write the ppm images with the data from device. This example scales the data
+ // from camera to unsigned char for storing in the ppm file.  For Scaling Distance data 
+ // Maximum distance is considered as 2.5m or 2500mm whereas for amplitude data min and max values are calculated 
+ // from data (auto scaling)  
+
+#include <iostream>
+#include <limits.h>
+#include <memory>
+#include <string>
+#include <thinks/ppm.hpp>
+#include <ifm3d/camera.h>
+#include <ifm3d/fg.h>
+#include <ifm3d/simpleimage.h>
+
+
+
+using namespace std;
+
+
+
+bool writePPMFile(ifm3d::SimpleImageBuffer::Img &img, std::string const& filename)
+{
+	auto const write_width = (size_t)img.width;
+	auto const write_height = (size_t)img.height;
+	auto write_pixels = vector<uint8_t>(write_width * write_height * 3); // 3 for RGB channels 
+	auto pixel_index = size_t{ 0 };
+	for (auto col = size_t{ 0 }; col < write_height; ++col) {
+		for (auto row = size_t{ 0 }; row < write_width; ++row) {
+			write_pixels[pixel_index * 3 + 0] = static_cast<uint8_t>(*(img.data.data() + pixel_index));
+			write_pixels[pixel_index * 3 + 1] = static_cast<uint8_t>(*(img.data.data() + pixel_index));
+			write_pixels[pixel_index * 3 + 2] = static_cast<uint8_t>(*(img.data.data() + pixel_index));
+			++pixel_index;
+		}
+	}
+	try
+	{
+		thinks::ppm::writeRgbImage(filename, write_width, write_height, write_pixels);
+	}
+	catch (exception e)
+	{
+		std::cerr << e.what();
+		return false;
+	}
+	return true;
+}
+// scales the data with min max values 
+template <typename  T>
+void scaleImageToRGB(ifm3d::SimpleImageBuffer::Img &input, ifm3d::SimpleImageBuffer::Img &confidence, ifm3d::SimpleImageBuffer::Img &output, double min = 0.0f, double max = 0.0f)
+{
+	output.width = input.width;
+	output.height = input.height;
+	output.format = ifm3d::pixel_format::FORMAT_8U;
+	output.data.resize(output.width*output.height);
+
+	float scalingFactor = 255.0 / ((max - min) != 0 ? (max - min) : 1);
+
+	for (int index = 0; index < input.width * input.height; index++)
+	{
+		T value = *((T*)(input.data.data()) + index);
+		if ((*(confidence.data.data() + index) & 0x01) == 0x00) // checking valid pixel 
+			*(output.data.data() + index) = (uint8_t)((value - min)* scalingFactor);
+		else
+		{
+			*(output.data.data() + index) = 0; // All invalid pixels 
+		}
+	}
+}
+
+// find the min max of the data
+template < typename  T >
+void findMinAndMax(ifm3d::SimpleImageBuffer::Img &input, ifm3d::SimpleImageBuffer::Img &confidence, double &min, double &max)
+{
+	max = 0;
+	min = (double)INT_MAX;
+	for (int index = 0; index < input.width * input.height; index++)
+	{
+		T value = *((T*)(input.data.data()) + index);
+		if ((*(confidence.data.data() + index) & 0x01) == 0x00)
+		{
+			min = std::min((T)min, value);
+		}
+		if ((*(confidence.data.data() + index) & 0x01) == 0x00)
+		{
+			max = std::max((T)max, value);
+		}
+	}
+}
+
+int main(int argc, const char **argv)
+{
+	auto cam = ifm3d::Camera::MakeShared();
+
+	ifm3d::SimpleImageBuffer::Ptr img = std::make_shared<ifm3d::SimpleImageBuffer>();
+	ifm3d::FrameGrabber::Ptr fg =
+		std::make_shared<ifm3d::FrameGrabber>(
+			cam, ifm3d::IMG_AMP | ifm3d::IMG_CART | ifm3d::IMG_RDIS);
+
+	if (!fg->WaitForFrame(img.get(), 1000))
+	{
+		std::cerr << "Timeout waiting for camera!" << std::endl;
+		return -1;
+	}
+	// acquiring data from the device 
+	ifm3d::SimpleImageBuffer::Img confidence = img->ConfidenceImage();
+	ifm3d::SimpleImageBuffer::Img amplitude = img->AmplitudeImage();
+	ifm3d::SimpleImageBuffer::Img distance = img->DistanceImage();
+
+	// for storing scaled output 
+	ifm3d::SimpleImageBuffer::Img distance_scaled;
+	ifm3d::SimpleImageBuffer::Img amplitude_scaled;
+
+	double min = 0.0;
+	double max = 0.0;
+	// max and mindistance for scaling distance image uint8 format 
+	auto const max_distance = 2.5;
+	auto const min_distance = 0.0;
+	// for 32F data  O3X camera
+	if (distance.format == ifm3d::pixel_format::FORMAT_32F)
+	{
+		scaleImageToRGB<float>(distance, confidence, distance_scaled, min_distance, max_distance);
+		findMinAndMax<float>(amplitude, confidence, min, max);
+		scaleImageToRGB<float>(amplitude, confidence, amplitude_scaled, min, max);
+	}
+	//for 16u data  O3D camera
+	else if(distance.format == ifm3d::pixel_format::FORMAT_16U)
+	{	  //if data format is 16U then distances are in millimeters, Hence max distance is multiplied by 1000. 
+		scaleImageToRGB<unsigned short>(distance, confidence, distance_scaled, min_distance, max_distance * 1000);
+		findMinAndMax<unsigned short>(amplitude, confidence, min, max);
+		scaleImageToRGB<unsigned short>(amplitude, confidence, amplitude_scaled, min, max);
+	}
+	else
+	{
+		std::cerr << "Unknown Format" << std::endl;
+	}
+
+	//writing images too ppm format 
+	if (!writePPMFile(distance_scaled, "distanceImage.ppm"))
+	{
+		std::cerr << "Not able to write the distance data in ppm format" << std::endl;
+		return -1;
+	}
+
+	if (!writePPMFile(amplitude_scaled, "amplitudeImage.ppm"))
+	{
+		std::cerr << "Not able to write the amplitude data in ppm format" << std::endl;
+		return -1;
+	}
+
+	std::cout << "Done with simpleimage ppmio example" << std::endl;
+	return 0;
+}

--- a/simpleimage/ppm-io-master/CMakeLists.txt
+++ b/simpleimage/ppm-io-master/CMakeLists.txt
@@ -1,0 +1,19 @@
+project(PPMIO CXX)
+set(PPMIO_MODULE_NAME "PPMIO")
+
+################################################
+## "build" for header-only library
+################################################
+
+add_library(ppmio INTERFACE)
+target_include_directories(ppmio INTERFACE include/)
+
+target_compile_options(ppmio
+  INTERFACE $<$<COMPILE_LANGUAGE:CXX>:-std=c++${CMAKE_CXX_STANDARD}>
+  )
+set_target_properties(ppmio PROPERTIES
+  EXPORT_NAME ppmio
+  )
+ 
+
+

--- a/simpleimage/ppm-io-master/LICENSE
+++ b/simpleimage/ppm-io-master/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Tommy Hinks
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/simpleimage/ppm-io-master/README.md
+++ b/simpleimage/ppm-io-master/README.md
@@ -1,0 +1,54 @@
+# PPM IO
+This repository implements reading and writing of images in the [PPM format](http://netpbm.sourceforge.net/doc/ppm.html). The PPM image format is extremely simple, making it ideal for small exploratory projects. The major benefit of this simplicity is that is it possible to implement the PPM file format without using external dependencies, such as compression libraries. All production code in this repository is implemented in a single [header file](https://github.com/thinks/ppm-io/blob/master/include/thinks/ppm.hpp), making it very simple to add to any existing project without having to set up additional linker rules. Also, the implementation uses only standard types and holds no state, meaning it should be fairly straight-forward to use the read and write functions. Detailed documentation is available in the source code.
+
+All code in this repository is released under the [MIT license](https://en.wikipedia.org/wiki/MIT_License).
+
+## Usage
+The implementation supports both reading and writing of PPM images. We provide some brief usage examples here, also refer to the [tests](https://github.com/thinks/ppm-io/blob/master/test/include/thinks/testPpm.hpp) for further examples.
+
+Reading an image is done as follows.
+```cpp
+using namespace std;
+
+auto width = size_t{0};
+auto height = size_t{0};
+auto pixel_data = vector<uint8_t>();
+auto ifs = ifstream("my_file.ppm", ios::binary);
+thinks::ppm::readRgbImage(ifs, &width, &height, &pixel_data);
+ifs.close();
+```
+The above version uses the stream interface. This interface is the most flexible, since it does not assume that the image is stored on disk. Also, this version is useful for testing since it allows the tests to run in memory avoiding file permission issues. However, since the image being stored on disk is probably the most likely scenario a convenience version is also available.
+```cpp
+using namespace std;
+
+auto width = size_t{0};
+auto height = size_t{0};
+auto pixel_data = vector<uint8_t>();
+thinks::ppm::readRgbImage("my_file.ppm", &width, &height, &pixel_data);
+```
+
+Writing image files is done in a similar fashion.
+```cpp
+using namespace std;
+
+// Write a 10x10 image where all pixels have the value (128, 128, 128).
+auto const width = size_t{10};
+auto const height = size_t{10};
+auto pixel_data = vector<uint8_t>(width * height * 3, 128);
+auto ofs = ofstream("my_file.ppm", ios::binary);
+thinks::ppm::writeRgbImage(ofs, width, height, pixel_data);
+ofs.close();
+```
+Again, there is a convenience version for writing to disk.
+```cpp
+using namespace std;
+
+// Write a 10x10 image where all pixels have the value (128, 128, 128).
+auto const width = size_t{10};
+auto const height = size_t{10};
+auto pixel_data = vector<uint8_t>(width * height * 3, 128);
+thinks::ppm::writeRgbImage("my_file.ppm", width, height, pixel_data);
+```
+
+## Tests
+This repository includes a simple [CMake project](https://github.com/thinks/ppm-io/blob/master/test/CMakeLists.txt) for running a small test suite. The test can be found in [this](https://github.com/thinks/ppm-io/blob/master/test/include/thinks/testPpm.hpp) header file. At present the test project builds and runs without errors.

--- a/simpleimage/ppm-io-master/include/thinks/ppm.hpp
+++ b/simpleimage/ppm-io-master/include/thinks/ppm.hpp
@@ -1,0 +1,191 @@
+// Copyright 2018 Tommy Hinks
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+#ifndef THINKS_PPM_PPM_HPP_INCLUDED
+#define THINKS_PPM_PPM_HPP_INCLUDED
+
+#include <cassert>
+#include <cstdint>
+#include <exception>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace thinks {
+namespace ppm {
+namespace detail {
+
+template <typename F>
+inline F openFileStream(std::string const& filename,
+                        std::ios_base::openmode const mode = std::ios::binary) {
+  using namespace std;
+
+  auto ofs = F(filename, mode);
+  if (ofs.fail()) {
+    auto ss = stringstream();
+    ss << "cannot open file '" << filename << "'";
+    throw runtime_error(ss.str());
+  }
+
+  return ofs;
+}
+
+}  // namespace detail
+
+//! Read a PPM image from an input stream.
+//!
+//! Assumptions:
+//! - the PPM header does not contain any comments.
+//! - the PPM header width and height are non-zero.
+//! - the input pointers are non-null.
+//!
+//! Pixel data is read as RGB triplets in row major order. For instance,
+//! the pixel data for a 2x2 image is represented as follows:
+//!
+//!       | Column 0                         | Column 1
+//!       +----------------------------------+------------------------------------+
+//! Row 0 | RGB: {data[0], data[1], data[2]} | RGB: {data[3], data[4], data[5]}
+//! |
+//!       +----------------------------------+------------------------------------+
+//! Row 1 | RGB: {data[6], data[7], data[8]} | RGB: {data[9], data[10],
+//! data[11]} |
+//!       +----------------------------------+------------------------------------+
+//!
+//! An std::runtime_error is thrown if:
+//! - the magic number is not 'P6'.
+//! - the max value is not '255'.
+//! - the pixel data cannot be read.
+inline void readRgbImage(std::istream& is, std::size_t* width,
+                         std::size_t* height,
+                         std::vector<std::uint8_t>* pixel_data) {
+  using namespace std;
+
+  assert(width != nullptr);
+  assert(height != nullptr);
+  assert(pixel_data != nullptr);
+
+  // Read header.
+  auto const expected_magic_number = string("P6");
+  auto const expected_max_value = string("255");
+  auto magic_number = string();
+  auto max_value = string();
+  is >> magic_number >> *width >> *height >> max_value;
+
+  assert(*width != 0);
+  assert(*height != 0);
+
+  if (magic_number != expected_magic_number) {
+    auto ss = stringstream();
+    ss << "magic number must be '" << expected_magic_number << "'";
+    throw runtime_error(ss.str());
+  }
+
+  if (max_value != expected_max_value) {
+    auto ss = stringstream();
+    ss << "max value must be " << expected_max_value;
+    throw runtime_error(ss.str());
+  }
+
+  // Skip ahead (an arbitrary number!) to the pixel data.
+  is.ignore(256, '\n');
+
+  // Read pixel data.
+  pixel_data->resize((*width) * (*height) * 3);
+  is.read(reinterpret_cast<char*>(pixel_data->data()), pixel_data->size());
+
+  if (!is) {
+    auto ss = stringstream();
+    ss << "failed reading " << pixel_data->size() << " bytes";
+    throw runtime_error(ss.str());
+  }
+}
+
+//! See std::istream overload version above.
+//!
+//! Throws an std::runtime_error if file cannot be opened.
+inline void readRgbImage(std::string const& filename, std::size_t* width,
+                         std::size_t* height,
+                         std::vector<std::uint8_t>* pixel_data) {
+  auto ifs = detail::openFileStream<std::ifstream>(filename);
+  readRgbImage(ifs, width, height, pixel_data);
+  ifs.close();
+}
+
+//! Write a PPM image to an output stream.
+//!
+//! Pixel data is given as RGB triplets in row major order. For instance,
+//! the pixel data for a 2x2 image is represented as follows:
+//!
+//!       | Column 0                         | Column 1
+//!       +----------------------------------+------------------------------------+
+//! Row 0 | RGB: {data[0], data[1], data[2]} | RGB: {data[3], data[4], data[5]}
+//! |
+//!       +----------------------------------+------------------------------------+
+//! Row 1 | RGB: {data[6], data[7], data[8]} | RGB: {data[9], data[10],
+//! data[11]} |
+//!       +----------------------------------+------------------------------------+
+//!
+//! An std::runtime_error is thrown if:
+//! - width or height is zero.
+//! - the size of the pixel data does not match the width and height.
+inline void writeRgbImage(std::ostream& os, std::size_t const width,
+                          std::size_t const height,
+                          std::vector<std::uint8_t> const& pixel_data) {
+  using namespace std;
+
+  if (width == 0) {
+    throw runtime_error("width must be non-zero");
+  }
+
+  if (height == 0) {
+    throw runtime_error("height must be non-zero");
+  }
+
+  if (pixel_data.size() != width * height * 3) {
+    throw runtime_error("pixel data must match width and height");
+  }
+
+  // Write header.
+  auto const magic_number = string("P6");
+  auto const max_value = string("255");
+  os << magic_number << "\n"
+     << width << " " << height << "\n"
+     << max_value << "\n";  // Marks beginning of pixel data.
+
+  // Write pixel data.
+  os.write(reinterpret_cast<char const*>(pixel_data.data()), pixel_data.size());
+}
+
+//! See std::ostream overload version above.
+//!
+//! Throws an std::runtime_error if file cannot be opened.
+inline void writeRgbImage(std::string const& filename, std::size_t const width,
+                          std::size_t const height,
+                          std::vector<std::uint8_t> const& pixel_data) {
+  auto ofs = detail::openFileStream<std::ofstream>(filename);
+  writeRgbImage(ofs, width, height, pixel_data);
+  ofs.close();
+}
+
+}  // namespace ppm
+}  // namespace thinks
+
+#endif  // THINKS_PPM_PPM_HPP_INCLUDED

--- a/simpleimage/simpleimage/CMakeLists.txt
+++ b/simpleimage/simpleimage/CMakeLists.txt
@@ -1,0 +1,26 @@
+
+project(SIMPLEIMAGE CXX)
+set(SIMPLEIMAGE_MODULE_NAME "simpleimage")
+
+################################################
+## "build" for header-only library
+################################################
+add_library(simpleimage INTERFACE)
+target_include_directories(simpleimage INTERFACE include/)
+
+target_compile_options(simpleimage
+  INTERFACE $<$<COMPILE_LANGUAGE:CXX>:-std=c++${CMAKE_CXX_STANDARD}>
+  )
+
+target_link_libraries(simpleimage
+  INTERFACE
+    ifm3d::framegrabber
+	ifm3d::camera
+    )
+	
+set_target_properties(simpleimage PROPERTIES
+  EXPORT_NAME simpleimage
+  )
+
+
+

--- a/simpleimage/simpleimage/include/ifm3d/simpleimage.h
+++ b/simpleimage/simpleimage/include/ifm3d/simpleimage.h
@@ -1,0 +1,23 @@
+// -*- c++ -*-
+/*
+ * Copyright (C) 2018 ifm electronic, gmbh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distribted on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __IFM3D_SIMPLEIMAGE_H__
+#define __IFM3D_SIMPLEIMAGE_H__
+
+#include <ifm3d/simpleimage/simpleimage_buffer.h>
+
+#endif // __IFM3D_SIMPLEIMAGE_H__

--- a/simpleimage/simpleimage/include/ifm3d/simpleimage/detail/simpleimage_buffer.hpp
+++ b/simpleimage/simpleimage/include/ifm3d/simpleimage/detail/simpleimage_buffer.hpp
@@ -1,0 +1,242 @@
+// -*- c++ -*-
+/*
+ * Copyright (C) 2018 ifm electronic, gmbh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distribted on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __IFM3D_SIMPLEIMAGE_DETAIL_SIMPLEIMAGE_BUFFER_HPP__
+#define __IFM3D_SIMPLEIMAGE_DETAIL_SIMPLEIMAGE_BUFFER_HPP__
+
+#include <cstdint>
+#include <unordered_map>
+#include <vector>
+#include <ifm3d/fg/byte_buffer.h>
+
+
+//==============================================
+// simpleImage Buffer implementation
+//==============================================
+
+ifm3d::SimpleImageBuffer::SimpleImageBuffer()
+  : ifm3d::ByteBuffer<ifm3d::SimpleImageBuffer>()
+{ }
+
+ifm3d::SimpleImageBuffer::~SimpleImageBuffer() = default;
+
+// move ctor
+ifm3d::SimpleImageBuffer::SimpleImageBuffer(ifm3d::SimpleImageBuffer&& src_buff)
+  : ifm3d::SimpleImageBuffer::SimpleImageBuffer()
+{
+  this->SetBytes(src_buff.bytes_, false);
+}
+
+// move assignment
+ifm3d::SimpleImageBuffer&
+ifm3d::SimpleImageBuffer::operator= (ifm3d::SimpleImageBuffer&& src_buff)
+{
+  this->SetBytes(src_buff.bytes_, false);
+  return *this;
+}
+
+// copy ctor
+ifm3d::SimpleImageBuffer::SimpleImageBuffer(const ifm3d::SimpleImageBuffer& src_buff)
+  : ifm3d::SimpleImageBuffer::SimpleImageBuffer()
+{
+  this->SetBytes(const_cast<std::vector<std::uint8_t>&>(src_buff.bytes_),
+                 true);
+}
+
+// copy assignment
+ifm3d::SimpleImageBuffer&
+ifm3d::SimpleImageBuffer::operator= (const ifm3d::SimpleImageBuffer& src_buff)
+{
+  if (this == &src_buff)
+    {
+      return *this;
+    }
+
+  this->SetBytes(const_cast<std::vector<std::uint8_t>&>(src_buff.bytes_),
+                 true);
+  return *this;
+}
+
+ifm3d::SimpleImageBuffer::Img
+ifm3d::SimpleImageBuffer::DistanceImage()
+{
+  this->Organize();
+  return this->dist_;
+}
+
+ifm3d::SimpleImageBuffer::Img
+ifm3d::SimpleImageBuffer::UnitVectors()
+{
+  this->Organize();
+  return this->uvec_;
+}
+
+ifm3d::SimpleImageBuffer::Img
+ifm3d::SimpleImageBuffer::GrayImage()
+{
+  this->Organize();
+  return this->gray_;
+}
+
+ifm3d::SimpleImageBuffer::Img
+ifm3d::SimpleImageBuffer::AmplitudeImage()
+{
+  this->Organize();
+  return this->amp_;
+}
+
+ifm3d::SimpleImageBuffer::Img
+ifm3d::SimpleImageBuffer::RawAmplitudeImage()
+{
+  this->Organize();
+  return this->ramp_;
+}
+
+ifm3d::SimpleImageBuffer::Img
+ifm3d::SimpleImageBuffer::ConfidenceImage()
+{
+  this->Organize();
+  return this->conf_;
+}
+
+ifm3d::SimpleImageBuffer::Img
+ifm3d::SimpleImageBuffer::XYZImage()
+{
+  this->Organize();
+  return this->xyz_;
+}
+
+template <typename T>
+void
+ifm3d::SimpleImageBuffer::ImCreate(ifm3d::image_chunk im,
+                              std::uint32_t fmt,
+                              std::size_t idx,
+                              std::uint32_t width,
+                              std::uint32_t height,
+                              int nchan,
+                              std::uint32_t npts,
+                              const std::vector<std::uint8_t>& bytes)
+{
+  Img *img;
+  switch (im)
+    {
+    case ifm3d::image_chunk::CONFIDENCE:
+      img = &this->conf_;
+      break;
+
+    case ifm3d::image_chunk::AMPLITUDE:
+      img = &this->amp_;
+      break;
+
+    case ifm3d::image_chunk::RADIAL_DISTANCE:
+      img = &this->dist_;
+      break;
+
+    case ifm3d::image_chunk::UNIT_VECTOR_ALL:
+      img = &this->uvec_;
+      break;
+
+    case ifm3d::image_chunk::RAW_AMPLITUDE:
+      img = &this->ramp_;
+      break;
+
+    case ifm3d::image_chunk::GRAY:
+      img = &this->gray_;
+      break;
+
+    default:
+      return;
+    }
+
+	std::size_t incr = sizeof(T) * nchan;
+	img->data.resize(sizeof(T)*nchan*width*height);
+    img->format = static_cast<pixel_format>(fmt);
+    img->width = width;
+    img->height = height;
+    
+
+   for (std::size_t i = 0; i < (npts*nchan); i++ )
+      {
+        const std::uint8_t* src = bytes.data() + idx + (i * sizeof(T));
+        std::uint8_t* dst = img->data.data() + (i * sizeof(T));
+
+        copy_data<T>(src, dst);
+      }
+}
+
+template <typename T>
+void
+ifm3d::SimpleImageBuffer::CloudCreate(std::uint32_t fmt,
+                                 std::size_t xidx,
+                                 std::size_t yidx,
+                                 std::size_t zidx,
+                                 std::uint32_t width,
+                                 std::uint32_t height,
+                                 std::uint32_t npts,
+                                 const std::vector<std::uint8_t>& bytes)
+{
+   std::size_t incr = sizeof(T);
+	Img *img = &this->xyz_;
+	img->data.resize(3*npts*incr);
+    img->format = static_cast<pixel_format>(fmt);
+    img->width = width;
+    img->height = height;
+	PointCloud *cloud = &this->cloud_;
+    cloud->width = width;
+    cloud->height = height;
+    cloud->points.resize(npts);
+
+	T x_, y_, z_;
+
+    // We assume, if the data from the sensor are a floating point type,
+    // the data are in meters, otherwise, the sensor is sending an
+    // integer type and the data are in mm.
+    bool convert_to_meters = true;
+    if ((img->format == pixel_format::FORMAT_32F) || (img->format == pixel_format::FORMAT_64F))
+      {
+        convert_to_meters = false;
+      }
+
+    for (std::size_t i = 0; i < npts;  i++, xidx += incr, yidx += incr, zidx += incr)
+    {
+        Point& pt = cloud->points[i];
+
+        // convert to ifm3d coord frame
+        x_ = ifm3d::mkval<T>(bytes.data()+zidx);
+        y_ = -ifm3d::mkval<T>(bytes.data()+xidx);
+        z_ = -ifm3d::mkval<T>(bytes.data()+yidx);
+
+        copy_data<T>(bytes.data() + zidx, img->data.data() + 3 * i * incr);
+        copy_data<T>(bytes.data() + xidx, img->data.data() + 3 * i * incr + incr);
+        copy_data<T>(bytes.data() + yidx, img->data.data() + 3 * i * incr + (2 * incr));
+
+        if (convert_to_meters)
+        {
+            pt.x = x_ / 1000.0f;
+            pt.y = y_ / 1000.0f;
+            pt.z = z_ / 1000.0f;
+        }
+        else
+        {
+            pt.x = x_;
+            pt.y = y_;
+            pt.z = z_;
+        }
+    }
+}
+
+#endif // __IFM3D_SIMPLEIMAGE_DETAIL_SIMPLEIMAGE_BUFFER_HPP__

--- a/simpleimage/simpleimage/include/ifm3d/simpleimage/simpleimage_buffer.h
+++ b/simpleimage/simpleimage/include/ifm3d/simpleimage/simpleimage_buffer.h
@@ -1,0 +1,163 @@
+// -*- c++ -*-
+/*
+ * Copyright (C) 2018 ifm electronic, gmbh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distribted on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __IFM3D_SIMPLEIMAGE_SIMPLEIMAGEBUFFER_BUFFER_H__
+#define __IFM3D_SIMPLEIMAGE_SIMPLEIMAGEBUFFER_BUFFER_H__
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+#include <ifm3d/fg/byte_buffer.h>
+
+namespace ifm3d
+{
+  /** copy the sizeof(T) bytes frm src to dst byte buffer. 
+   * Given that the ifm sensors transmit data in little endian
+   * format, this function will swap bytes if necessary for the host
+   * representation of T param
+   */
+	
+  template<typename T>
+  void copy_data(const std::uint8_t* src, std::uint8_t* dst)
+  {
+	#if !defined(_WIN32) && __BYTE_ORDER == __BIG_ENDIAN
+    std::reverse_copy(src, src + sizeof(T), dst);
+	#else
+    std::copy(src,  src + sizeof(T), dst);
+	#endif
+  }
+  class SimpleImageBuffer : public ifm3d::ByteBuffer<ifm3d::SimpleImageBuffer>
+  {
+  public:
+  
+  struct Img
+  {
+    std::vector<std::uint8_t> data;
+    int width;
+    int height;
+    pixel_format format;
+  };
+
+  struct Point
+  {
+    float x;
+    float y;
+    float z;
+  };
+
+  struct PointCloud
+  {
+    std::vector<Point> points;
+    int width;
+    int height;
+  };
+   
+    friend class ifm3d::ByteBuffer<ifm3d::SimpleImageBuffer>;
+    using Ptr = std::shared_ptr<SimpleImageBuffer>;
+
+    // ctor/dtor
+    SimpleImageBuffer();
+    ~SimpleImageBuffer();
+
+    // move semantics
+    SimpleImageBuffer(SimpleImageBuffer&&);
+    SimpleImageBuffer& operator=(SimpleImageBuffer&&);
+
+    // copy semantics
+    SimpleImageBuffer(const SimpleImageBuffer& src_buff);
+    SimpleImageBuffer& operator=(const SimpleImageBuffer& src_buff);
+
+    // accessors
+   /**
+   * Accessor for the wrapped radial distance image
+   */
+  Img DistanceImage();
+
+  /**
+   * Accessor for the wrapped unit vectors
+   */
+  Img UnitVectors();
+
+  /**
+   * Accessor the the wrapped ambient light image
+   */
+  Img GrayImage();
+
+  /**
+   * Accessor for the normalized amplitude image
+   */
+  Img AmplitudeImage();
+
+  /**
+   * Accessor for the raw amplitude image
+   */
+  Img RawAmplitudeImage();
+
+  /**
+   * Accessor for the confidence image
+   */
+  Img ConfidenceImage();
+
+  /**
+   * Accessor for the image encoding of the point cloud
+   *
+   * 3-channel image of spatial planes X, Y, Z
+   */
+  Img XYZImage();
+
+  /**
+   * Returns the point cloud
+   */
+  PointCloud Cloud();
+
+
+  protected:
+    template <typename T>
+    void ImCreate(ifm3d::image_chunk im,
+                  std::uint32_t fmt,
+                  std::size_t idx,
+                  std::uint32_t width,
+                  std::uint32_t height,
+                  int nchan,
+                  std::uint32_t npts,
+                  const std::vector<std::uint8_t>& bytes);
+
+    template <typename T>
+    void CloudCreate(std::uint32_t fmt,
+                     std::size_t xidx,
+                     std::size_t yidx,
+                     std::size_t zidx,
+                     std::uint32_t width,
+                     std::uint32_t height,
+                     std::uint32_t npts,
+                     const std::vector<std::uint8_t>& bytes);
+  private:
+  Img dist_;
+  Img uvec_;
+  Img gray_;
+  Img amp_;
+  Img ramp_;
+  Img conf_;
+  Img xyz_;
+  PointCloud cloud_;
+
+  }; // end: class SimpleImageBuffer
+} // end: namespace ifm3d
+
+#include <ifm3d/simpleimage/detail/simpleimage_buffer.hpp>
+
+#endif // __IFM3D_SIMPLEIMAGE_SIMPLEIMAGEBUFFER_BUFFER_H__


### PR DESCRIPTION
This example take the [usage guide](https://github.com/lovepark/ifm3d/blob/master/doc/img_container.md) for writing a custom image container and shows how to extract the image data and store it as PPM images. PPM was chosen because of it's simplicity. This shows how to extend the ifm3d by writing an own image container by sub classing the base class and not changing the ifm3d library itself.