### PR TITLE
Make some of the ifm3d modules optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ set(CMAKE_MODULE_PATH
 include(MacroOutOfSourceBuild)
 macro_ensure_out_of_source_build(
   "Please build ${PROJECT_NAME} out-of-source")
-  
+
 # Conditionally turn on/off parts of the build (global-level)
 option(BUILD_MODULE_SIMPLEIMAGE "Build the simpleimage module and example" ON)
 
@@ -17,9 +17,9 @@ option(BUILD_MODULE_SIMPLEIMAGE "Build the simpleimage module and example" ON)
 ## Bring in dependent projects
 ################################################
 find_package(ifm3d 0.9.0 CONFIG
-  REQUIRED COMPONENTS camera framegrabber image pcicclient
-  )
-
+    REQUIRED COMPONENTS camera framegrabber
+    OPTIONAL_COMPONENTS image pcicclient
+    )
 if(FORCE_OPENCV3)
   find_package(OpenCV 3 REQUIRED)
 elseif(FORCE_OPENCV2)
@@ -32,59 +32,60 @@ endif()
 if(BUILD_MODULE_SIMPLEIMAGE)
   add_definitions(-DBUILD_MODULE_SIMPLEIMAGE=ON)
   add_subdirectory(simpleimage)
-endif() 
+endif()
 
 ################################################
 ## Build the examples
 ################################################
-add_executable(ex-file_io ex-file_io.cpp)
-target_link_libraries(ex-file_io
-                      ifm3d::camera
-                      ifm3d::framegrabber
-                      ifm3d::image
-                      ${OpenCV_LIBRARIES}
-                      )
-
 add_executable(ex-getmac ex-getmac.cpp)
 target_link_libraries(ex-getmac ifm3d::camera)
 
-add_executable(ex-fast_app_switch ex-fast_app_switch.cpp)
-target_link_libraries(ex-fast_app_switch
-                      ifm3d::camera
-                      ifm3d::framegrabber
-                      ifm3d::image
-                      ifm3d::pcicclient
-                      )
+if((TARGET ifm3d::pcicclient) AND (TARGET ifm3d::image))
+    add_executable(ex-fast_app_switch ex-fast_app_switch.cpp)
+    target_link_libraries(ex-fast_app_switch
+        ifm3d::camera
+        ifm3d::framegrabber
+        ifm3d::image
+        ifm3d::pcicclient
+    )
+endif()
+if(TARGET ifm3d::image)
+    add_executable(ex-file_io ex-file_io.cpp)
+    target_link_libraries(ex-file_io
+            ifm3d::camera
+            ifm3d::framegrabber
+            ifm3d::image
+            ${OpenCV_LIBRARIES}
+    )
+    add_executable(ex-timestamp ex-timestamp.cpp)
+    target_link_libraries(ex-timestamp
+          ifm3d::camera
+          ifm3d::framegrabber
+          ifm3d::image
+    )
+    add_executable(ex-exposure_times ex-exposure_times.cpp)
+    target_link_libraries(ex-exposure_times
+          ifm3d::camera
+          ifm3d::framegrabber
+          ifm3d::image
+    )
+    add_executable(ex-multi_camera_grabber ex-multi_camera_grabber.cpp)
+    target_link_libraries(ex-multi_camera_grabber
+          ifm3d::camera
+          ifm3d::framegrabber
+          ifm3d::image
+    )
+endif()
+if(TARGET ifm3d::pcicclient)
+    add_executable(ex-pcicclient_set_io ex-pcicclient_set_io.cpp)
+    target_link_libraries(ex-pcicclient_set_io
+              ifm3d::camera
+              ifm3d::pcicclient
+    )
+    add_executable(ex-pcicclient_async_messages ex-pcicclient_async_messages.cpp)
+    target_link_libraries(ex-pcicclient_async_messages
+              ifm3d::camera
+              ifm3d::pcicclient
+    )
+endif()
 
-add_executable(ex-pcicclient_set_io ex-pcicclient_set_io.cpp)
-target_link_libraries(ex-pcicclient_set_io
-                      ifm3d::camera
-                      ifm3d::pcicclient
-                      )
-
-add_executable(ex-pcicclient_async_messages ex-pcicclient_async_messages.cpp)
-target_link_libraries(ex-pcicclient_async_messages
-                      ifm3d::camera
-                      ifm3d::pcicclient
-                      )
-
-add_executable(ex-timestamp ex-timestamp.cpp)
-target_link_libraries(ex-timestamp
-                      ifm3d::camera
-                      ifm3d::framegrabber
-                      ifm3d::image
-                      )
-
-add_executable(ex-exposure_times ex-exposure_times.cpp)
-target_link_libraries(ex-exposure_times
-                      ifm3d::camera
-                      ifm3d::framegrabber
-                      ifm3d::image
-                      )
-
-add_executable(ex-multi_camera_grabber ex-multi_camera_grabber.cpp)
-target_link_libraries(ex-multi_camera_grabber
-                    ifm3d::camera
-                    ifm3d::framegrabber
-                    ifm3d::image
-                    )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ option(BUILD_MODULE_SIMPLEIMAGE "Build the simpleimage module and example" ON)
 ################################################
 ## Bring in dependent projects
 ################################################
-find_package(ifm3d 0.9.0 CONFIG
+find_package(ifm3d 0.11.0 CONFIG
     REQUIRED COMPONENTS camera framegrabber
     OPTIONAL_COMPONENTS image pcicclient
     )


### PR DESCRIPTION
The ``pcicclient`` for example is turned off by default. So do ensure only
examples are build for which the dependency is fulfilled.

:warning: Please take care before this Pull-Request can be merged the Pull-Request [#98](https://github.com/lovepark/ifm3d/pull/98) needs to be merged.

Signed-off-by: Christian Ege <christian.ege@ifm.com>